### PR TITLE
Fix selection of examples; kudos to kocher

### DIFF
--- a/src/ExamplesDialog.css
+++ b/src/ExamplesDialog.css
@@ -40,4 +40,9 @@
 .examples-dialog .example-card .title {
   font-size: 1.5em;
   color: #162162;
+  pointer-events: none;
+}
+
+.examples-dialog .example-card .description {
+  pointer-events: none;
 }


### PR DESCRIPTION
The selection of example style now also works if you click on the text within the dialog box.

Kudos go to @dnlkoch 