### PR TITLE
Add SLD 1.1.0 parser to StyleLoader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -313,7 +313,8 @@ class App extends React.Component<AppProps, AppState> {
               <Form.Item>
                 <StyleLoader
                   parsers={[
-                    this._sldStyleParser
+                    this._sldStyleParser,
+                    this._sldStyleParserSE
                   ]}
                   onStyleRead={(style: GsStyle) => {
                     this.setState({style});


### PR DESCRIPTION
@krishnaglodha please notice

This adds the 'SLD 1.1.0 - Symbology Encoding' parser to the StyleLoader to allow uploading of SLDs with Symbology Encoding.

fixes #324 