### PR TITLE
GeoStyler v9

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -36,9 +36,9 @@ module.exports = {
     alias: {
       react: require.resolve('react'),
       // uncomment for development with npm link
-      // 'geostyler-style': path.resolve('node_modules/geostyler-style/'),
-      // 'geostyler-sld-parser': path.resolve('node_modules/geostyler-sld-parser/'),
-      // 'antd': path.resolve('node_modules/antd/')
+      // 'geostyler-style': path.resolve('node_modules', 'geostyler-style'),
+      // 'geostyler-sld-parser': path.resolve('node_modules', 'geostyler-sld-parser'),
+      // 'antd': path.resolve('node_modules', 'antd')
     }
   },
   output: {

--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -35,12 +35,15 @@ module.exports = {
     },
     alias: {
       react: require.resolve('react'),
-      'geostyler-style': path.resolve('node_modules/geostyler-style/')
+      // uncomment for development with npm link
+      // 'geostyler-style': path.resolve('node_modules/geostyler-style/'),
+      // 'geostyler-sld-parser': path.resolve('node_modules/geostyler-sld-parser/'),
+      // 'antd': path.resolve('node_modules/antd/')
     }
   },
   output: {
     filename: 'bundle.js',
-    path: path.resolve(__dirname, '../dist')
+    path: path.resolve(__dirname, '..', 'dist')
   },
   plugins: [
     new HtmlWebpackPlugin({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/react-dom": "^17.0.12",
         "antd": "^4.15.3",
         "d3": "^6.7.0",
-        "geostyler": "^8.1.1",
+        "geostyler": "^9.0.1",
         "geostyler-geojson-parser": "^1.0.1",
         "geostyler-legend": "^2.1.0",
         "geostyler-shapefile-parser": "^1.0.0",
@@ -354,24 +354,24 @@
       }
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "node_modules/@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "node_modules/@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "node_modules/@types/arcgis-rest-api": {
       "version": "10.4.5",
@@ -4566,9 +4566,9 @@
       "dev": true
     },
     "node_modules/geostyler": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/geostyler/-/geostyler-8.1.1.tgz",
-      "integrity": "sha512-X0oNaqJt7/tju53zdE94cdPnpVXRnPMbroTA89tBodwhus/sMlUFFyUKzWV0Dk38iGTKrdi0EPfGrL7F9TZIbg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/geostyler/-/geostyler-9.0.1.tgz",
+      "integrity": "sha512-6GF6RQlN8H9ApynGx/aGMztIgV9ioWCMsZKxDwblVNXAd7/rLyxKD6JgIAItSOzhcni5P5LOzjQFI35ES9ty/A==",
       "dependencies": {
         "@babel/polyfill": "^7.12.1",
         "@monaco-editor/react": "^4.3.1",
@@ -4589,16 +4589,16 @@
         "geostyler-cql-parser": "^1.1.0",
         "geostyler-data": "^1.0.0",
         "geostyler-geojson-parser": "^1.0.1",
-        "geostyler-openlayers-parser": "^3.0.1",
+        "geostyler-openlayers-parser": "^3.1.0",
         "geostyler-sld-parser": "^3.2.2",
-        "geostyler-style": "^5.0.2",
+        "geostyler-style": "^5.1.0",
         "geostyler-wfs-parser": "^1.0.1",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "monaco-editor": "^0.33.0",
         "react-color": "^2.19.3",
         "react-rnd": "^10.2.4",
-        "typescript-json-schema": "^0.53.0"
+        "typescript-json-schema": "^0.54.0"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -4660,16 +4660,22 @@
       }
     },
     "node_modules/geostyler-openlayers-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
       "dependencies": {
+        "color-name": "^1.1.4",
         "geostyler-style": "^5.0.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
         "ol": "^6.0.0"
       }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/geostyler-shapefile-parser": {
       "version": "1.0.0",
@@ -7105,9 +7111,10 @@
       }
     },
     "node_modules/path-equal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.1.2.tgz",
-      "integrity": "sha512-p5kxPPwCdbf5AdXzT1bUBJomhgBlEjRBavYNr1XUpMFIE4Hnf2roueCMXudZK5tnaAu1tTmp3GPzqwJK45IHEA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.2.2.tgz",
+      "integrity": "sha512-AUJvbcle1Zgb1TgtftHYknlrgrSYyI1ytrYgSbKUHSybwqUDnbD2cw9PIWivuMvsN+GTXmr/DRN4VBXpHG6aGg==",
+      "hasInstallScript": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -9644,9 +9651,9 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9743,14 +9750,14 @@
       }
     },
     "node_modules/typescript-json-schema": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.53.1.tgz",
-      "integrity": "sha512-Hg+RnOKUd38MOzC0rDft03a8xvwO+gCcj1F77smw2tCoZYQpFoLtrXWBGdvCX+REliko5WYel2kux17HPFqjLQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.54.0.tgz",
+      "integrity": "sha512-/MNhm1pjdxXiVspjjyRCrQAA1B768cRzHU83aIqN5vQqQEW2NgyyKOfcguiRIMM64lseIZIelegnHOHEu7YDCg==",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/node": "^16.9.2",
         "glob": "^7.1.7",
-        "path-equal": "1.1.2",
+        "path-equal": "^1.1.2",
         "safe-stable-stringify": "^2.2.0",
         "ts-node": "^10.2.1",
         "typescript": "~4.6.0",
@@ -9766,9 +9773,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/typescript-json-schema/node_modules/@types/node": {
-      "version": "16.11.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.39.tgz",
-      "integrity": "sha512-K0MsdV42vPwm9L6UwhIxMAOmcvH/1OoVkZyCgEtVu4Wx7sElGloy/W7kMBNe/oJ7V/jW9BVt1F6RahH6e7tPXw=="
+      "version": "16.11.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
+      "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ=="
     },
     "node_modules/typescript-json-schema/node_modules/typescript": {
       "version": "4.6.4",
@@ -10746,24 +10753,24 @@
       "optional": true
     },
     "@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "@types/arcgis-rest-api": {
       "version": "10.4.5",
@@ -14224,9 +14231,9 @@
       "dev": true
     },
     "geostyler": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/geostyler/-/geostyler-8.1.1.tgz",
-      "integrity": "sha512-X0oNaqJt7/tju53zdE94cdPnpVXRnPMbroTA89tBodwhus/sMlUFFyUKzWV0Dk38iGTKrdi0EPfGrL7F9TZIbg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/geostyler/-/geostyler-9.0.1.tgz",
+      "integrity": "sha512-6GF6RQlN8H9ApynGx/aGMztIgV9ioWCMsZKxDwblVNXAd7/rLyxKD6JgIAItSOzhcni5P5LOzjQFI35ES9ty/A==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@monaco-editor/react": "^4.3.1",
@@ -14247,16 +14254,16 @@
         "geostyler-cql-parser": "^1.1.0",
         "geostyler-data": "^1.0.0",
         "geostyler-geojson-parser": "^1.0.1",
-        "geostyler-openlayers-parser": "^3.0.1",
+        "geostyler-openlayers-parser": "^3.1.0",
         "geostyler-sld-parser": "^3.2.2",
-        "geostyler-style": "^5.0.2",
+        "geostyler-style": "^5.1.0",
         "geostyler-wfs-parser": "^1.0.1",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "monaco-editor": "^0.33.0",
         "react-color": "^2.19.3",
         "react-rnd": "^10.2.4",
-        "typescript-json-schema": "^0.53.0"
+        "typescript-json-schema": "^0.54.0"
       }
     },
     "geostyler-cql-parser": {
@@ -14301,12 +14308,20 @@
       }
     },
     "geostyler-openlayers-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
       "requires": {
+        "color-name": "^1.1.4",
         "geostyler-style": "^5.0.2",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
       }
     },
     "geostyler-shapefile-parser": {
@@ -16166,9 +16181,9 @@
       }
     },
     "path-equal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.1.2.tgz",
-      "integrity": "sha512-p5kxPPwCdbf5AdXzT1bUBJomhgBlEjRBavYNr1XUpMFIE4Hnf2roueCMXudZK5tnaAu1tTmp3GPzqwJK45IHEA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.2.2.tgz",
+      "integrity": "sha512-AUJvbcle1Zgb1TgtftHYknlrgrSYyI1ytrYgSbKUHSybwqUDnbD2cw9PIWivuMvsN+GTXmr/DRN4VBXpHG6aGg=="
     },
     "path-exists": {
       "version": "4.0.0",
@@ -18112,9 +18127,9 @@
       }
     },
     "ts-node": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -18170,14 +18185,14 @@
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "typescript-json-schema": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.53.1.tgz",
-      "integrity": "sha512-Hg+RnOKUd38MOzC0rDft03a8xvwO+gCcj1F77smw2tCoZYQpFoLtrXWBGdvCX+REliko5WYel2kux17HPFqjLQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.54.0.tgz",
+      "integrity": "sha512-/MNhm1pjdxXiVspjjyRCrQAA1B768cRzHU83aIqN5vQqQEW2NgyyKOfcguiRIMM64lseIZIelegnHOHEu7YDCg==",
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/node": "^16.9.2",
         "glob": "^7.1.7",
-        "path-equal": "1.1.2",
+        "path-equal": "^1.1.2",
         "safe-stable-stringify": "^2.2.0",
         "ts-node": "^10.2.1",
         "typescript": "~4.6.0",
@@ -18190,9 +18205,9 @@
           "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
         },
         "@types/node": {
-          "version": "16.11.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.39.tgz",
-          "integrity": "sha512-K0MsdV42vPwm9L6UwhIxMAOmcvH/1OoVkZyCgEtVu4Wx7sElGloy/W7kMBNe/oJ7V/jW9BVt1F6RahH6e7tPXw=="
+          "version": "16.11.45",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
+          "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ=="
         },
         "typescript": {
           "version": "4.6.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@types/react-dom": "^17.0.12",
     "antd": "^4.15.3",
     "d3": "^6.7.0",
-    "geostyler": "^8.1.1",
+    "geostyler": "^9.0.1",
     "geostyler-geojson-parser": "^1.0.1",
     "geostyler-legend": "^2.1.0",
     "geostyler-shapefile-parser": "^1.0.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
 declare module '*.svg' {
-    const content: string;
-    export default content;
+  const content: string;
+  export default content;
 }


### PR DESCRIPTION
This updates `geostyler` to v9.0.1 and adapts the demo code accordingly.
It also adds some smaller modifications to the webpack config.

Closes #358 