### PR TITLE
fix: add missing events dependency needed for xml2js on qgis parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/react-dom": "^18.3.0",
         "antd": "^5.18.0",
         "d3": "^7.9.0",
+        "events": "^3.3.0",
         "geostyler": "^17.0.0",
         "geostyler-geojson-parser": "^2.0.0",
         "geostyler-legend": "^5.0.1",
@@ -4567,6 +4568,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/react-dom": "^18.3.0",
     "antd": "^5.18.0",
     "d3": "^7.9.0",
+    "events": "^3.3.0",
     "geostyler": "^17.0.0",
     "geostyler-geojson-parser": "^2.0.0",
     "geostyler-legend": "^5.0.1",


### PR DESCRIPTION
This fixes https://github.com/geostyler/geostyler-qgis-parser/issues/608 by adding a missing dependency that is needed for browser builds that want to use xml2js. In the long run, we should probably replace xml2js in geostyler-qgis-parser to circumvent this problem.